### PR TITLE
Add static-dashboard and remove duplicate sun-panel entry

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -54,5 +54,5 @@ https://github.com/RayeRen/acad-homepage.github.io
 https://github.com/hywax/mafl
 https://github.com/hslr-s/sun-panel
 https://github.com/mattermost/focalboard
-https://github.com/hslr-s/sun-panel
 https://github.com/gethomepage/homepage
+https://github.com/mina-ai-assistant/static-dashboard


### PR DESCRIPTION
Hi Uncle,

   Thanks for maintaining this list.

   This PR does two small cleanup updates to `list.txt`:
   - adds `[https://github.com/mina-ai-assistant/static-dashboard`](https://github.com/mina-ai-assistant/static-dashboard)
   - removes the duplicate `[https://github.com/hslr-s/sun-panel`](https://github.com/hslr-s/sun-panel%60) entry

   Kept it minimal on purpose.